### PR TITLE
Fix WordPress salt command execution

### DIFF
--- a/install_wordpress.sh
+++ b/install_wordpress.sh
@@ -140,14 +140,14 @@ define( 'DB_HOST', 'localhost' );
 define( 'DB_CHARSET', 'utf8mb4' );
 define( 'DB_COLLATE', '' );
 
-define('AUTH_KEY',         '$(curl -s https://api.wordpress.org/secret-key/1.1/salt/)');
-define('SECURE_AUTH_KEY',  '$(curl -s https://api.wordpress.org/secret-key/1.1/salt/)');
-define('LOGGED_IN_KEY',    '$(curl -s https://api.wordpress.org/secret-key/1.1/salt/)');
-define('NONCE_KEY',        '$(curl -s https://api.wordpress.org/secret-key/1.1/salt/)');
-define('AUTH_SALT',        '$(curl -s https://api.wordpress.org/secret-key/1.1/salt/)');
-define('SECURE_AUTH_SALT', '$(curl -s https://api.wordpress.org/secret-key/1.1/salt/)');
-define('LOGGED_IN_SALT',   '$(curl -s https://api.wordpress.org/secret-key/1.1/salt/)');
-define('NONCE_SALT',       '$(curl -s https://api.wordpress.org/secret-key/1.1/salt/)');
+define('AUTH_KEY',         $(curl -s https://api.wordpress.org/secret-key/1.1/salt/));
+define('SECURE_AUTH_KEY',  $(curl -s https://api.wordpress.org/secret-key/1.1/salt/));
+define('LOGGED_IN_KEY',    $(curl -s https://api.wordpress.org/secret-key/1.1/salt/));
+define('NONCE_KEY',        $(curl -s https://api.wordpress.org/secret-key/1.1/salt/));
+define('AUTH_SALT',        $(curl -s https://api.wordpress.org/secret-key/1.1/salt/));
+define('SECURE_AUTH_SALT', $(curl -s https://api.wordpress.org/secret-key/1.1/salt/));
+define('LOGGED_IN_SALT',   $(curl -s https://api.wordpress.org/secret-key/1.1/salt/));
+define('NONCE_SALT',       $(curl -s https://api.wordpress.org/secret-key/1.1/salt/));
 
 \$table_prefix = 'wp_';
 define( 'WP_DEBUG', false );

--- a/install_wordpress_ssl.sh
+++ b/install_wordpress_ssl.sh
@@ -147,14 +147,14 @@ define( 'DB_HOST', 'localhost' );
 define( 'DB_CHARSET', 'utf8mb4' );
 define( 'DB_COLLATE', '' );
 
-define('AUTH_KEY',         '$(curl -s https://api.wordpress.org/secret-key/1.1/salt/)');
-define('SECURE_AUTH_KEY',  '$(curl -s https://api.wordpress.org/secret-key/1.1/salt/)');
-define('LOGGED_IN_KEY',    '$(curl -s https://api.wordpress.org/secret-key/1.1/salt/)');
-define('NONCE_KEY',        '$(curl -s https://api.wordpress.org/secret-key/1.1/salt/)');
-define('AUTH_SALT',        '$(curl -s https://api.wordpress.org/secret-key/1.1/salt/)');
-define('SECURE_AUTH_SALT', '$(curl -s https://api.wordpress.org/secret-key/1.1/salt/)');
-define('LOGGED_IN_SALT',   '$(curl -s https://api.wordpress.org/secret-key/1.1/salt/)');
-define('NONCE_SALT',       '$(curl -s https://api.wordpress.org/secret-key/1.1/salt/)');
+define('AUTH_KEY',         $(curl -s https://api.wordpress.org/secret-key/1.1/salt/));
+define('SECURE_AUTH_KEY',  $(curl -s https://api.wordpress.org/secret-key/1.1/salt/));
+define('LOGGED_IN_KEY',    $(curl -s https://api.wordpress.org/secret-key/1.1/salt/));
+define('NONCE_KEY',        $(curl -s https://api.wordpress.org/secret-key/1.1/salt/));
+define('AUTH_SALT',        $(curl -s https://api.wordpress.org/secret-key/1.1/salt/));
+define('SECURE_AUTH_SALT', $(curl -s https://api.wordpress.org/secret-key/1.1/salt/));
+define('LOGGED_IN_SALT',   $(curl -s https://api.wordpress.org/secret-key/1.1/salt/));
+define('NONCE_SALT',       $(curl -s https://api.wordpress.org/secret-key/1.1/salt/));
 
 \$table_prefix = 'wp_';
 define( 'WP_DEBUG', false );


### PR DESCRIPTION
## Summary
- unquote salt generation commands in install scripts
- validate script syntax with `bash -n`

## Testing
- `bash -n install_wordpress.sh`
- `bash -n install_wordpress_ssl.sh`


------
https://chatgpt.com/codex/tasks/task_e_686c283b78f883238405185bc8ca0689