### PR TITLE
Fix security and correctness issues in WordPress install scripts

### DIFF
--- a/install_wordpress.sh
+++ b/install_wordpress.sh
@@ -1,16 +1,24 @@
 #!/bin/bash
 
+set -e
+
 # Prompt for domain name
 read -p "Enter your domain name (e.g., example.com): " DOMAIN
+[[ -z "$DOMAIN" ]] && { echo "Error: Domain name cannot be empty."; exit 1; }
 
 # Prompt for email address for Let's Encrypt
 read -p "Enter your email address (for Let's Encrypt SSL): " EMAIL
+[[ -z "$EMAIL" ]] && { echo "Error: Email address cannot be empty."; exit 1; }
+
+# Prompt for MariaDB root password
+read -sp "Enter your MariaDB root password: " DB_ROOT_PASSWORD
+echo
+[[ -z "$DB_ROOT_PASSWORD" ]] && { echo "Error: MariaDB root password cannot be empty."; exit 1; }
 
 # Variables
 DB_NAME="wordpress_$(echo $DOMAIN | tr . _)"
 DB_USER="wp_user_$(echo $DOMAIN | tr . _)"
-DB_PASSWORD=$(openssl rand -base64 16) # Generate a random password
-DB_ROOT_PASSWORD="root_password" # Update with your MariaDB root password
+DB_PASSWORD=$(openssl rand -base64 16)
 WORDPRESS_DIR="/var/www/$DOMAIN"
 
 # Update system packages
@@ -63,8 +71,8 @@ cat <<EOL > /etc/apache2/sites-available/$DOMAIN.conf
         Require all granted
     </Directory>
 
-    ErrorLog \${APACHE_LOG_DIR}/$DOMAIN_error.log
-    CustomLog \${APACHE_LOG_DIR}/$DOMAIN_access.log combined
+    ErrorLog \${APACHE_LOG_DIR}/${DOMAIN}_error.log
+    CustomLog \${APACHE_LOG_DIR}/${DOMAIN}_access.log combined
 </VirtualHost>
 EOL
 
@@ -107,8 +115,8 @@ cat <<EOL > /etc/apache2/sites-available/$DOMAIN-ssl.conf
     Header always set Referrer-Policy "strict-origin-when-cross-origin"
     Header always set Permissions-Policy "geolocation=(), microphone=(), camera=()"
 
-    ErrorLog \${APACHE_LOG_DIR}/$DOMAIN_error.log
-    CustomLog \${APACHE_LOG_DIR}/$DOMAIN_access.log combined
+    ErrorLog \${APACHE_LOG_DIR}/${DOMAIN}_error.log
+    CustomLog \${APACHE_LOG_DIR}/${DOMAIN}_access.log combined
 </VirtualHost>
 EOL
 
@@ -123,11 +131,14 @@ systemctl reload apache2
 echo "Downloading and configuring WordPress..."
 wget -q https://wordpress.org/latest.tar.gz -O /tmp/latest.tar.gz
 mkdir -p $WORDPRESS_DIR
-tar -xzf /tmp/latest.tar.gz -C /tmp
-mv /tmp/wordpress/* $WORDPRESS_DIR
+tar -xzf /tmp/latest.tar.gz -C $WORDPRESS_DIR --strip-components=1
 chown -R www-data:www-data $WORDPRESS_DIR
 find $WORDPRESS_DIR -type d -exec chmod 755 {} \;
 find $WORDPRESS_DIR -type f -exec chmod 644 {} \;
+
+# Fetch WordPress secret keys
+echo "Fetching WordPress secret keys..."
+WP_SALTS=$(curl -s https://api.wordpress.org/secret-key/1.1/salt/)
 
 # Create wp-config.php
 echo "Creating WordPress configuration file..."
@@ -140,14 +151,7 @@ define( 'DB_HOST', 'localhost' );
 define( 'DB_CHARSET', 'utf8mb4' );
 define( 'DB_COLLATE', '' );
 
-define('AUTH_KEY',         $(curl -s https://api.wordpress.org/secret-key/1.1/salt/));
-define('SECURE_AUTH_KEY',  $(curl -s https://api.wordpress.org/secret-key/1.1/salt/));
-define('LOGGED_IN_KEY',    $(curl -s https://api.wordpress.org/secret-key/1.1/salt/));
-define('NONCE_KEY',        $(curl -s https://api.wordpress.org/secret-key/1.1/salt/));
-define('AUTH_SALT',        $(curl -s https://api.wordpress.org/secret-key/1.1/salt/));
-define('SECURE_AUTH_SALT', $(curl -s https://api.wordpress.org/secret-key/1.1/salt/));
-define('LOGGED_IN_SALT',   $(curl -s https://api.wordpress.org/secret-key/1.1/salt/));
-define('NONCE_SALT',       $(curl -s https://api.wordpress.org/secret-key/1.1/salt/));
+$WP_SALTS
 
 \$table_prefix = 'wp_';
 define( 'WP_DEBUG', false );

--- a/install_wordpress_ssl.sh
+++ b/install_wordpress_ssl.sh
@@ -5,15 +5,21 @@ set -e
 
 # Prompt for domain name
 read -p "Enter your domain name (e.g., example.com): " DOMAIN
+[[ -z "$DOMAIN" ]] && { echo "Error: Domain name cannot be empty."; exit 1; }
 
 # Prompt for email address for Let's Encrypt
 read -p "Enter your email address (for Let's Encrypt SSL): " EMAIL
+[[ -z "$EMAIL" ]] && { echo "Error: Email address cannot be empty."; exit 1; }
+
+# Prompt for MariaDB root password
+read -sp "Enter your MariaDB root password: " DB_ROOT_PASSWORD
+echo
+[[ -z "$DB_ROOT_PASSWORD" ]] && { echo "Error: MariaDB root password cannot be empty."; exit 1; }
 
 # Variables
 DB_NAME="wordpress_$(echo $DOMAIN | tr . _)"
 DB_USER="wp_user_$(echo $DOMAIN | tr . _)"
 DB_PASSWORD=$(openssl rand -base64 16) # Generate a random password
-DB_ROOT_PASSWORD="root_password" # Update with your MariaDB root password
 WORDPRESS_DIR="/var/www/$DOMAIN"
 
 # Update system packages
@@ -66,15 +72,15 @@ cat <<EOL > /etc/apache2/sites-available/$DOMAIN.conf
         Require all granted
     </Directory>
 
-    ErrorLog \${APACHE_LOG_DIR}/$DOMAIN_error.log
-    CustomLog \${APACHE_LOG_DIR}/$DOMAIN_access.log combined
+    ErrorLog \${APACHE_LOG_DIR}/${DOMAIN}_error.log
+    CustomLog \${APACHE_LOG_DIR}/${DOMAIN}_access.log combined
 </VirtualHost>
 EOL
 
 # Enable Apache configurations
 echo "Enabling Apache configurations..."
 a2ensite $DOMAIN
-a2enmod rewrite headers
+a2enmod rewrite ssl headers
 apachectl configtest
 systemctl reload apache2
 
@@ -115,8 +121,8 @@ cat <<EOL > /etc/apache2/sites-available/$DOMAIN-ssl.conf
     Header always set Referrer-Policy "strict-origin-when-cross-origin"
     Header always set Permissions-Policy "geolocation=(), microphone=(), camera=()"
 
-    ErrorLog \${APACHE_LOG_DIR}/$DOMAIN_error.log
-    CustomLog \${APACHE_LOG_DIR}/$DOMAIN_access.log combined
+    ErrorLog \${APACHE_LOG_DIR}/${DOMAIN}_error.log
+    CustomLog \${APACHE_LOG_DIR}/${DOMAIN}_access.log combined
 </VirtualHost>
 EOL
 
@@ -136,6 +142,10 @@ chown -R www-data:www-data $WORDPRESS_DIR
 find $WORDPRESS_DIR -type d -exec chmod 755 {} \;
 find $WORDPRESS_DIR -type f -exec chmod 644 {} \;
 
+# Fetch WordPress secret keys
+echo "Fetching WordPress secret keys..."
+WP_SALTS=$(curl -s https://api.wordpress.org/secret-key/1.1/salt/)
+
 # Create wp-config.php
 echo "Creating WordPress configuration file..."
 cat <<EOL > $WORDPRESS_DIR/wp-config.php
@@ -147,14 +157,7 @@ define( 'DB_HOST', 'localhost' );
 define( 'DB_CHARSET', 'utf8mb4' );
 define( 'DB_COLLATE', '' );
 
-define('AUTH_KEY',         $(curl -s https://api.wordpress.org/secret-key/1.1/salt/));
-define('SECURE_AUTH_KEY',  $(curl -s https://api.wordpress.org/secret-key/1.1/salt/));
-define('LOGGED_IN_KEY',    $(curl -s https://api.wordpress.org/secret-key/1.1/salt/));
-define('NONCE_KEY',        $(curl -s https://api.wordpress.org/secret-key/1.1/salt/));
-define('AUTH_SALT',        $(curl -s https://api.wordpress.org/secret-key/1.1/salt/));
-define('SECURE_AUTH_SALT', $(curl -s https://api.wordpress.org/secret-key/1.1/salt/));
-define('LOGGED_IN_SALT',   $(curl -s https://api.wordpress.org/secret-key/1.1/salt/));
-define('NONCE_SALT',       $(curl -s https://api.wordpress.org/secret-key/1.1/salt/));
+$WP_SALTS
 
 \$table_prefix = 'wp_';
 define( 'WP_DEBUG', false );
@@ -169,4 +172,3 @@ echo "Setting up SSL renewal cron job..."
 (crontab -l 2>/dev/null; echo "0 2 * * * certbot renew --quiet >> /var/log/letsencrypt/renew.log") | crontab -
 
 echo "Installation completed! Visit https://$DOMAIN to complete WordPress setup."
-


### PR DESCRIPTION
- Add set -e to install_wordpress.sh for immediate error exit
- Replace hardcoded MariaDB root password with interactive prompt
- Add input validation for domain, email, and root password
- Fix log file variable expansion bug (\$DOMAIN_error -> \${DOMAIN}_error)
- Fix wp-config.php salt generation: fetch once via curl, inject as block
- Fix WordPress extraction to use --strip-components=1 (install_wordpress.sh)
- Add missing a2enmod ssl to install_wordpress_ssl.sh

https://claude.ai/code/session_01VMs3K4mK9USc2ww8yDGsPX