### PR TITLE
Add VPS tuning (2 vCPU / 4GB) and Redis to `installv2.txt` WordPress installer

### DIFF
--- a/installv2.txt
+++ b/installv2.txt
@@ -1,0 +1,251 @@
+# WordPress Linux Installation Guide (v2) - Updated 2026
+# Target: Debian/Ubuntu with Apache + PHP-FPM + MariaDB + Let's Encrypt
+# Run commands with sudo (do not stay logged in as root for the full session).
+
+set -euo pipefail
+
+#############################################
+# 0) REQUIRED VARIABLES (edit these first)
+#############################################
+DOMAIN="example.com"
+EMAIL="admin@example.com"
+SITE_ROOT="/var/www/${DOMAIN}/public"
+DB_NAME="wordpress"
+DB_USER="wpuser"
+DB_PASS="change_this_to_a_strong_password"
+
+#############################################
+# 1) BASE SYSTEM SETUP
+#############################################
+sudo hostnamectl set-hostname "${DOMAIN}"
+sudo apt update
+sudo DEBIAN_FRONTEND=noninteractive apt upgrade -y
+sudo apt install -y \
+  ca-certificates curl wget unzip git bash-completion net-tools rsync \
+  software-properties-common apt-transport-https
+
+#############################################
+# 2) INSTALL APACHE, MARIADB, PHP 8.3
+#############################################
+sudo apt install -y apache2 mariadb-server mariadb-client
+sudo apt install -y \
+  php8.3-fpm php8.3-cli php8.3-common php8.3-curl php8.3-mbstring \
+  php8.3-imagick php8.3-intl php8.3-xml php8.3-zip php8.3-opcache \
+  php8.3-redis php8.3-mysql php8.3-bcmath
+
+sudo systemctl enable --now apache2 mariadb php8.3-fpm
+
+#############################################
+# 3) MARIADB HARDENING + WORDPRESS DATABASE
+#############################################
+# Run interactive hardening (recommended):
+sudo mysql_secure_installation
+
+# Create WordPress DB + user (safe to re-run).
+sudo mysql <<SQL
+CREATE DATABASE IF NOT EXISTS \`${DB_NAME}\` CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+CREATE USER IF NOT EXISTS '${DB_USER}'@'localhost' IDENTIFIED BY '${DB_PASS}';
+GRANT ALL PRIVILEGES ON \`${DB_NAME}\`.* TO '${DB_USER}'@'localhost';
+FLUSH PRIVILEGES;
+SQL
+
+#############################################
+# 4) APACHE MODULES + PHP-FPM INTEGRATION
+#############################################
+sudo a2enmod rewrite ssl headers http2 proxy_fcgi setenvif
+sudo a2enconf php8.3-fpm
+
+# Create dedicated site directories.
+sudo mkdir -p "${SITE_ROOT}"
+sudo chown -R www-data:www-data "/var/www/${DOMAIN}"
+
+# Create HTTP vhost.
+sudo tee "/etc/apache2/sites-available/${DOMAIN}.conf" >/dev/null <<APACHE_HTTP
+<VirtualHost *:80>
+    ServerName ${DOMAIN}
+    ServerAlias www.${DOMAIN}
+    DocumentRoot ${SITE_ROOT}
+
+    <Directory ${SITE_ROOT}>
+        Options FollowSymLinks
+        AllowOverride All
+        Require all granted
+    </Directory>
+
+    ErrorLog \\${APACHE_LOG_DIR}/${DOMAIN}_error.log
+    CustomLog \\${APACHE_LOG_DIR}/${DOMAIN}_access.log combined
+</VirtualHost>
+APACHE_HTTP
+
+sudo a2dissite 000-default.conf || true
+sudo a2ensite "${DOMAIN}.conf"
+sudo apache2ctl -t
+sudo systemctl reload apache2
+
+#############################################
+# 5) INSTALL WORDPRESS
+#############################################
+cd /tmp
+wget -q https://wordpress.org/latest.tar.gz
+rm -rf /tmp/wordpress
+mkdir -p /tmp/wordpress
+
+tar -xzf latest.tar.gz -C /tmp
+sudo rsync -a --delete /tmp/wordpress/ "${SITE_ROOT}/"
+
+sudo chown -R www-data:www-data "/var/www/${DOMAIN}"
+sudo find "${SITE_ROOT}" -type d -exec chmod 755 {} \;
+sudo find "${SITE_ROOT}" -type f -exec chmod 644 {} \;
+
+# Configure wp-config.php
+cd "${SITE_ROOT}"
+if [ ! -f wp-config.php ]; then
+  sudo cp wp-config-sample.php wp-config.php
+fi
+
+sudo sed -i "s/database_name_here/${DB_NAME}/" wp-config.php
+sudo sed -i "s/username_here/${DB_USER}/" wp-config.php
+sudo sed -i "s/password_here/${DB_PASS}/" wp-config.php
+# Add strong salts automatically.
+SALT="$(curl -fsSL https://api.wordpress.org/secret-key/1.1/salt/)"
+sudo awk -v salts="$SALT" '
+  BEGIN{added=0}
+  /AUTH_KEY|SECURE_AUTH_KEY|LOGGED_IN_KEY|NONCE_KEY|AUTH_SALT|SECURE_AUTH_SALT|LOGGED_IN_SALT|NONCE_SALT/ && added==0 {
+    print salts
+    added=1
+    next
+  }
+  !/AUTH_KEY|SECURE_AUTH_KEY|LOGGED_IN_KEY|NONCE_KEY|AUTH_SALT|SECURE_AUTH_SALT|LOGGED_IN_SALT|NONCE_SALT/ {print}
+' wp-config.php | sudo tee /tmp/wp-config.php.new >/dev/null
+sudo mv /tmp/wp-config.php.new wp-config.php
+
+sudo chmod 640 wp-config.php
+
+#############################################
+# 6) TLS CERTIFICATE (LET'S ENCRYPT)
+#############################################
+sudo apt install -y certbot python3-certbot-apache
+sudo certbot --apache \
+  --non-interactive \
+  --agree-tos \
+  --email "${EMAIL}" \
+  -d "${DOMAIN}" -d "www.${DOMAIN}" \
+  --redirect
+
+# Confirm certbot auto-renew timer.
+sudo systemctl enable --now certbot.timer
+sudo systemctl list-timers --all | grep certbot || true
+
+#############################################
+# 7) APACHE SECURITY HEADERS + TLS TUNING
+#############################################
+# Apply safe defaults in SSL vhost if needed.
+# NOTE: certbot modifies vhost files automatically; validate after edits.
+
+sudo tee /etc/apache2/conf-available/security-headers.conf >/dev/null <<'HEADERS'
+Header always set X-Frame-Options "SAMEORIGIN"
+Header always set X-Content-Type-Options "nosniff"
+Header always set Referrer-Policy "strict-origin-when-cross-origin"
+Header always set Permissions-Policy "geolocation=(), microphone=(), camera=()"
+Header always set Strict-Transport-Security "max-age=63072000; includeSubDomains; preload"
+HEADERS
+
+sudo a2enconf security-headers
+sudo apache2ctl -t
+sudo systemctl reload apache2
+
+#############################################
+# 8) PHP TUNING FOR WORDPRESS
+#############################################
+PHP_INI="/etc/php/8.3/fpm/php.ini"
+sudo sed -i 's/^memory_limit = .*/memory_limit = 256M/' "$PHP_INI"
+sudo sed -i 's/^upload_max_filesize = .*/upload_max_filesize = 64M/' "$PHP_INI"
+sudo sed -i 's/^post_max_size = .*/post_max_size = 64M/' "$PHP_INI"
+sudo sed -i 's/^max_execution_time = .*/max_execution_time = 300/' "$PHP_INI"
+sudo sed -i 's/^;*opcache.enable=.*/opcache.enable=1/' "$PHP_INI"
+sudo sed -i 's/^;*opcache.memory_consumption=.*/opcache.memory_consumption=128/' "$PHP_INI"
+
+sudo systemctl restart php8.3-fpm apache2
+
+
+#############################################
+# 9) VPS BASELINE TUNING (2 vCPU / 4GB RAM)
+#############################################
+# 9.1 Add swap (recommended on 4GB systems to avoid OOM kills during updates).
+if ! sudo swapon --show | grep -q '/swapfile'; then
+  sudo fallocate -l 2G /swapfile || sudo dd if=/dev/zero of=/swapfile bs=1M count=2048
+  sudo chmod 600 /swapfile
+  sudo mkswap /swapfile
+  sudo swapon /swapfile
+  echo '/swapfile none swap sw 0 0' | sudo tee -a /etc/fstab
+fi
+
+# Tune VM pressure for web workloads.
+echo 'vm.swappiness=10' | sudo tee /etc/sysctl.d/99-wordpress-vm.conf >/dev/null
+echo 'vm.vfs_cache_pressure=50' | sudo tee -a /etc/sysctl.d/99-wordpress-vm.conf >/dev/null
+sudo sysctl --system
+
+# 9.2 Apache MPM Event tuning for small VPS capacity.
+sudo tee /etc/apache2/mods-available/mpm_event.conf >/dev/null <<'APACHE_MPM'
+<IfModule mpm_event_module>
+    StartServers             2
+    MinSpareThreads         25
+    MaxSpareThreads         75
+    ThreadLimit             64
+    ThreadsPerChild         25
+    MaxRequestWorkers      150
+    MaxConnectionsPerChild 1000
+</IfModule>
+APACHE_MPM
+
+# 9.3 PHP-FPM pool sizing for 4GB RAM (balanced for WordPress + MariaDB).
+PHP_POOL='/etc/php/8.3/fpm/pool.d/www.conf'
+sudo sed -i 's/^pm = .*/pm = dynamic/' "$PHP_POOL"
+sudo sed -i 's/^pm.max_children = .*/pm.max_children = 35/' "$PHP_POOL"
+sudo sed -i 's/^pm.start_servers = .*/pm.start_servers = 4/' "$PHP_POOL"
+sudo sed -i 's/^pm.min_spare_servers = .*/pm.min_spare_servers = 4/' "$PHP_POOL"
+sudo sed -i 's/^pm.max_spare_servers = .*/pm.max_spare_servers = 10/' "$PHP_POOL"
+sudo sed -i 's/^;*pm.max_requests = .*/pm.max_requests = 500/' "$PHP_POOL"
+
+# 9.4 MariaDB basic memory tuning for 4GB RAM.
+sudo tee /etc/mysql/mariadb.conf.d/60-wordpress-tuning.cnf >/dev/null <<'MYSQL_TUNE'
+[mysqld]
+innodb_buffer_pool_size = 1G
+innodb_log_file_size = 256M
+innodb_flush_method = O_DIRECT
+max_connections = 80
+thread_cache_size = 50
+table_open_cache = 2000
+tmp_table_size = 64M
+max_heap_table_size = 64M
+MYSQL_TUNE
+
+# 9.5 Optional Redis object cache (recommended for dynamic WP sites).
+sudo apt install -y redis-server
+sudo systemctl enable --now redis-server
+
+# 9.6 Reload services after tuning.
+sudo systemctl restart mariadb php8.3-fpm apache2 redis-server
+
+#############################################
+# 10) FINAL CHECKS
+#############################################
+sudo apache2ctl -t
+sudo systemctl --no-pager --full status apache2 mariadb php8.3-fpm redis-server | sed -n '1,160p'
+sudo free -h
+sudo swapon --show
+
+echo "Open https://${DOMAIN} to finish the WordPress web installer."
+
+#############################################
+# 11) POST-INSTALL SECURITY + OPERATIONS
+#############################################
+# - Configure automated offsite backups (DB + files) and test restore monthly.
+# - Add uptime and resource monitoring (Netdata, Uptime Kuma, or cloud monitor).
+# - Enable a CDN + edge WAF (Cloudflare/Sucuri) for DDoS and bot mitigation.
+# - Use full-page caching (plugin + optional Redis object cache).
+# - Keep OS and WordPress core/themes/plugins patched.
+# - Limit wp-admin access (WAF, VPN, or IP allowlist where practical).
+# - Disable XML-RPC if not required.
+# - Add fail2ban / rate limiting.
+# - Install a trusted security plugin and enable MFA for admins.


### PR DESCRIPTION
### Motivation
- Provide host-level tuning and operational defaults for WordPress deployments on small VPS instances (2 vCPU, 4 GB RAM, 50 GB NVMe) to reduce OOMs and improve stability. 
- Recommend a small-cache, resource-aware stack (Apache MPM, PHP-FPM, MariaDB) and optional object caching to match constrained resources.

### Description
- Added a VPS tuning section to `installv2.txt` that creates a 2 GB swapfile and sets kernel VM parameters (`vm.swappiness`, `vm.vfs_cache_pressure`).
- Added Apache `mpm_event` baseline values and PHP-FPM pool sizing changes in `/etc/php/8.3/fpm/pool.d/www.conf` tuned for 4 GB RAM.
- Added a MariaDB tuning file at `/etc/mysql/mariadb.conf.d/60-wordpress-tuning.cnf` with conservative InnoDB and connection settings.
- Added installation and enablement of `redis-server` as an optional object cache and added service restarts and expanded final checks (`free -h`, `swapon --show`, service status including Redis).

### Testing
- Verified the inserted block and overall file structure with `nl -ba installv2.txt` and `sed -n '140,320p'` to confirm the tuning section is present. 
- Applied and validated the automated text patch with a Python replacement script to ensure the new section replaced the intended target block. 
- Confirmed this change is content-only and no provisioning/runtime commands were executed in the environment during validation.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e679d19b08832384b9eebb4b2e71a3)