### PR TITLE
Overhaul install scripts: PHP-FPM, multi-site, hardened SSL, add_site.sh

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,26 +1,58 @@
-**Install Wordpress on Debian or Ubuntu in few easy steps.**
+# WordPress on Linux
 
-Updated on January 2026
+Install WordPress on Debian or Ubuntu in a few easy steps.
 
-Keep it simple. No need for fancy plugins or many services. 
-For most cases a virtual machine with 1vCPU and 1GB RAM is enough.
-Also use a CDN it helps a lot. Cloudflare is a good option (has a free plan that is perfect for small sized installations).
+> **Keep it simple.** No fancy plugins, no bloated stack. For most sites a VM with 1 vCPU and 1 GB RAM is plenty.
 
-Some **recommended** plugins
-- Akismet antispam https://wordpress.org/plugins/akismet/ install it even if comments are disabled.
-- Disable comments https://wordpress.org/plugins/disable-comments/ (install it if you do not like criticism like me)
-- WP Fastest cache  https://wordpress.org/plugins/wp-fastest-cache/ In most cases the free version is enough.
-- WP mail SMTP https://wordpress.org/plugins/wp-mail-smtp/ No need to install mail server on your linux box.
-**Optional** plugins
-- Google XML Sitemaps https://wordpress.org/plugins/google-sitemap-generator/
-- All-in-One WP Migration https://wordpress.org/plugins/all-in-one-wp-migration/
-- WP DoNotTrack https://wordpress.org/plugins/wp-donottrack/
+---
 
-If you are looking for hosting your virtual machine (or vps as they called nowdays)
-Vultr, digital ocean or Linode are all very good options. Another option is to use AWS Lightsail but it is untested by me.
-Both AWS and Azure offer free tiers worth of trying.
+## Scripts
 
-Make you webserver installation more secure. Check out this nice tool **https://ssl-config.mozilla.org/**
+| Script | Purpose |
+|---|---|
+| `install.txt` | Full server setup — Apache, MariaDB, PHP-FPM, SSL, WordPress |
+| `install_wordpress.sh` | Automated single-site install with Let's Encrypt |
+| `install_wordpress_ssl.sh` | Automated single-site install, SSL via webroot method |
+| `add_site.sh` | Add a new WordPress site to an existing server |
 
+Sites are installed under `/var/www/html/<domain>`.
 
+---
 
+## Recommended Plugins
+
+- **[Akismet Anti-Spam](https://wordpress.org/plugins/akismet/)** — install even if comments are disabled.
+- **[Disable Comments](https://wordpress.org/plugins/disable-comments/)** — removes the comment system entirely.
+- **[WP Fastest Cache](https://wordpress.org/plugins/wp-fastest-cache/)** — the free version covers most small sites.
+- **[WP Mail SMTP](https://wordpress.org/plugins/wp-mail-smtp/)** — sends email via an external provider; no mail server needed.
+
+### Optional
+
+- **[Google XML Sitemaps](https://wordpress.org/plugins/google-sitemap-generator/)**
+- **[All-in-One WP Migration](https://wordpress.org/plugins/all-in-one-wp-migration/)**
+- **[WP DoNotTrack](https://wordpress.org/plugins/wp-donottrack/)**
+
+---
+
+## Hosting
+
+Any of these work well for a small WordPress VPS:
+
+- **[Vultr](https://www.vultr.com)** / **[DigitalOcean](https://www.digitalocean.com)** / **[Linode](https://www.linode.com)** — straightforward, predictable pricing.
+- **AWS Lightsail** / **Azure** — both have free tiers worth exploring.
+
+---
+
+## Performance Tips
+
+- Put a CDN in front — [Cloudflare](https://www.cloudflare.com) has a free plan that works well for small installations.
+- Keep WordPress, themes, and plugins updated.
+
+## Security
+
+- Validate your SSL configuration with **[Mozilla SSL Config Generator](https://ssl-config.mozilla.org/)**.
+- Scripts enforce TLS 1.3 only with AEAD ciphers, HSTS, OCSP stapling, and HTTP → HTTPS redirect.
+
+---
+
+*Last updated: January 2026*


### PR DESCRIPTION
## Summary

- **PHP-FPM + mpm_event**: replaced mod_php/mpm_prefork across all scripts for better performance under load
- **Multi-site support**: site root changed to `/var/www/html/<domain>` to support multiple sites per server
- **`add_site.sh`**: new script to provision additional WordPress sites on an existing server (Apache vhosts, SSL, DB, WordPress) without reinstalling the stack
- **SSL hardening**: TLS 1.3 only, AEAD ciphers, no 0-RTT (session tickets off), no compression, OCSP stapling, HSTS
- **HTTP → HTTPS redirect**: port 80 vhost now redirects all traffic, with `/.well-known/` exempted for certbot renewals
- **Security fixes in shell scripts**: removed hardcoded root password (now prompted), added `set -e`, input validation, fixed log filename variable expansion bug, fixed wp-config.php salt generation
- **README**: rewritten with scripts table, structured sections, and links

## Test plan

- [ ] Run `install.txt` steps on a fresh Debian/Ubuntu VM and verify WordPress is reachable over HTTPS
- [ ] Run `add_site.sh` on the same server to add a second site and confirm both are independently accessible
- [ ] Confirm HTTP redirects to HTTPS and certbot renewal works (`certbot renew --dry-run`)
- [ ] Verify TLS 1.3 only with `nmap --script ssl-enum-ciphers -p 443 <domain>` or similar

https://claude.ai/code/session_01VMs3K4mK9USc2ww8yDGsPX