### PR TITLE
Add Redis, firewall, fail2ban, backups; fix certbot and www logic

### DIFF
--- a/install_wordpress.sh
+++ b/install_wordpress.sh
@@ -94,6 +94,11 @@ cat <<EOL > /etc/apache2/sites-available/$DOMAIN.conf
     ServerAlias www.$DOMAIN
     DocumentRoot $WORDPRESS_DIR
 
+    <Directory $WORDPRESS_DIR>
+        AllowOverride All
+        Require all granted
+    </Directory>
+
     RewriteEngine On
     RewriteCond %{REQUEST_URI} !^/\.well-known/
     RewriteRule ^ https://%{HTTP_HOST}%{REQUEST_URI} [R=301,L]
@@ -120,8 +125,16 @@ find $WORDPRESS_DIR -type f -exec chmod 644 {} \;
 
 # Obtain SSL certificate via webroot
 echo "Obtaining Let's Encrypt SSL certificate for $DOMAIN..."
-if ! certbot certonly --webroot -w $WORDPRESS_DIR --non-interactive --agree-tos \
-    --email $EMAIL -d $DOMAIN -d www.$DOMAIN; then
+CERTBOT_DOMAINS="-d $DOMAIN"
+WWW_ALIAS=""
+if getent hosts "www.$DOMAIN" &>/dev/null; then
+    CERTBOT_DOMAINS="$CERTBOT_DOMAINS -d www.$DOMAIN"
+    WWW_ALIAS="ServerAlias www.$DOMAIN"
+else
+    echo "Warning: www.$DOMAIN has no DNS record — requesting certificate for $DOMAIN only."
+fi
+if ! certbot certonly --webroot -w "$WORDPRESS_DIR" --non-interactive --agree-tos \
+    --email "$EMAIL" $CERTBOT_DOMAINS; then
     echo "Error: SSL certificate generation failed. Check DNS and ensure port 80 is accessible."
     exit 1
 fi
@@ -132,7 +145,7 @@ cat <<EOL > /etc/apache2/sites-available/$DOMAIN-ssl.conf
 <VirtualHost *:443>
     ServerAdmin $EMAIL
     ServerName $DOMAIN
-    ServerAlias www.$DOMAIN
+    $WWW_ALIAS
     DocumentRoot $WORDPRESS_DIR
 
     <Directory $WORDPRESS_DIR>

--- a/install_wordpress.sh
+++ b/install_wordpress.sh
@@ -21,6 +21,15 @@ DB_USER="wp_user_$(echo $DOMAIN | tr . _)"
 DB_PASSWORD=$(openssl rand -base64 16)
 WORDPRESS_DIR="/var/www/html/$DOMAIN"
 
+IFS='.' read -ra DOMAIN_PARTS <<< "$DOMAIN"
+if [ "${#DOMAIN_PARTS[@]}" -eq 2 ]; then
+    WWW_ALIAS="ServerAlias www.$DOMAIN"
+    CERTBOT_DOMAINS="-d $DOMAIN -d www.$DOMAIN"
+else
+    WWW_ALIAS=""
+    CERTBOT_DOMAINS="-d $DOMAIN"
+fi
+
 # Update system packages
 echo "Updating system packages..."
 apt update && apt upgrade -y
@@ -91,7 +100,7 @@ cat <<EOL > /etc/apache2/sites-available/$DOMAIN.conf
 <VirtualHost *:80>
     ServerAdmin $EMAIL
     ServerName $DOMAIN
-    ServerAlias www.$DOMAIN
+    $WWW_ALIAS
     DocumentRoot $WORDPRESS_DIR
 
     <Directory $WORDPRESS_DIR>
@@ -125,14 +134,6 @@ find $WORDPRESS_DIR -type f -exec chmod 644 {} \;
 
 # Obtain SSL certificate via webroot
 echo "Obtaining Let's Encrypt SSL certificate for $DOMAIN..."
-CERTBOT_DOMAINS="-d $DOMAIN"
-WWW_ALIAS=""
-if getent hosts "www.$DOMAIN" &>/dev/null; then
-    CERTBOT_DOMAINS="$CERTBOT_DOMAINS -d www.$DOMAIN"
-    WWW_ALIAS="ServerAlias www.$DOMAIN"
-else
-    echo "Warning: www.$DOMAIN has no DNS record — requesting certificate for $DOMAIN only."
-fi
 if ! certbot certonly --webroot -w "$WORDPRESS_DIR" --non-interactive --agree-tos \
     --email "$EMAIL" $CERTBOT_DOMAINS; then
     echo "Error: SSL certificate generation failed. Check DNS and ensure port 80 is accessible."


### PR DESCRIPTION
## Summary

- Add `redis-server`, `php-redis`, `ufw`, `fail2ban` to package install; start and enable Redis service
- Configure UFW (OpenSSH + Apache Full) and fail2ban with sshd + four Apache jails
- Add Redis constants (`WP_REDIS_HOST`, `WP_REDIS_PORT`, `WP_CACHE`) to `wp-config.php`; install WP-CLI and activate `redis-cache` plugin
- Create `/usr/local/bin/wp-backup.sh` (files + DB, 7-day retention) scheduled via `/etc/cron.d/wp-backup` at 03:00
- Fix certbot 404: add missing `<Directory>` block to HTTP vhost so Apache serves `.well-known/acme-challenge/` files
- Auto-detect bare domain vs subdomain at startup: add `www` only when input has exactly 2 parts (e.g. `orion.gr` → also `www.orion.gr`); skip `www` for subdomains (e.g. `artemis.orion.gr`)

---
_Generated by [Claude Code](https://claude.ai/code/session_01SxatgUysgDMRDVrDjsXuRv)_